### PR TITLE
2025/08/29 Release

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -102,6 +102,7 @@ jobs:
           
     - id: sign_executable
       name: "Sign XarChat.exe"
+      if: github.event_name != 'pull_request'
       shell: bash
       working-directory: "${{ github.workspace }}/host/win32-webview2/XarChatWin32WebView2/bin/Release/net9.0-windows10.0.17763.0/publish/win-x64/"
       run: |
@@ -112,6 +113,7 @@ jobs:
     - id: publish_artifact
       name: "Publish Artifact"
       #if: steps.extract_branch.outputs.publishartifact == 'true'
+      if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: win32-exe

--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -57,6 +57,24 @@ jobs:
       name: "Setup MSBuild"
       uses: microsoft/setup-msbuild@v2
 
+    - id: cache_nuget
+      name: "Cache NuGet"
+      uses: actions/cache@v3
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget
+        restore-keys: |
+          ${{ runner.os }}-nuget
+
+    - id: cache_npm
+      name: "Cache NPM"
+      uses: actions/cache@v3
+      with:
+        path: browser/mainapp/node_modules
+        key: ${{ runner.os }}-mainappnodemodules
+        restore-keys: |
+          ${{ runner.os }}-mainappnodemodules
+
     - id: restore_npm_deps
       name: "Restore NPM Packages"
       shell: bash
@@ -82,11 +100,20 @@ jobs:
       run: |
         msbuild.exe "${{ github.workspace }}\XarChat.sln" /nologo /nr:false /T:"Restore;win32\win32-webview2\XarChatWin32WebView2:Publish" /p:IsPublishing=true /p:AzureBuildNumber="${{ steps.generate_buildid.outputs.buildid }}" /p:Platform="Any CPU" /p:Configuration="Release" /p:VisualStudioVersion="17.0" 
           
+    - id: sign_executable
+      name: "Sign XarChat.exe"
+      shell: bash
+      working-directory: "${{ github.workspace }}/host/win32-webview2/XarChatWin32WebView2/bin/Release/net9.0-windows10.0.17763.0/publish/win-x64/"
+      run: |
+        curl -f -o XarChat.signed.exe -F "file=@XarChat.exe;filename=XarChat.exe" -F "password=${{ secrets.SIGNING_PASSWORD }}" ${{ secrets.SIGNING_SERVICE_URL }}
+        rm XarChat.exe
+        mv XarChat.signed.exe XarChat.exe
+
     - id: publish_artifact
       name: "Publish Artifact"
       #if: steps.extract_branch.outputs.publishartifact == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: win32-exe
-        path: ${{ github.workspace }}\host\win32-webview2\XarChatWin32WebView2\bin\Release\net9.0-windows10.0.17763.0\publish\
+        path: ${{ github.workspace }}/host/win32-webview2/XarChatWin32WebView2/bin/Release/net9.0-windows10.0.17763.0/publish/win-x64/XarChat.exe
         retention-days: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 * Added a configuration setting to have a PM tab open when someone starts typing to you
   (instead of waiting until they actually send you a message).  You can also control whether
   this pings you.
+* Added the ability to change the UI language in use (impacts spell check and other localization)
+  - Can set via a new setting under Global options
+  - Can also set via command line (e.g., `XarChat.exe --lang en-US`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Added some minor rendering optimizations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Added some minor rendering optimizations.
+* Fixed EIcon blocking (right-click on an EIcon to block it)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
 * Added some minor rendering optimizations.
 * Fixed EIcon blocking (right-click on an EIcon to block it)
+* Added a configuration setting to have a PM tab open when someone starts typing to you
+  (instead of waiting until they actually send you a message).  You can also control whether
+  this pings you.

--- a/XarChat.sln
+++ b/XarChat.sln
@@ -24,6 +24,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".git", ".git", "{653FA4C1-6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XarChat.AutoUpdate", "host\shared\XarChat.AutoUpdate\XarChat.AutoUpdate.csproj", "{03F75260-4093-45F9-9D64-1E2364CFB94A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D297E14C-17B2-483D-BBC0-20210A4DC951}"
+	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/browser/mainapp/src/components/ChannelStream.ts
+++ b/browser/mainapp/src/components/ChannelStream.ts
@@ -144,7 +144,7 @@ export class ChannelStream extends ComponentBase<ChannelViewModel> {
 
         elMessageContainer.addEventListener("copy", (e: ClipboardEvent) => {
             BBCodeParser.performCopy(e);
-        });
+        }, true);
         elScrolledUp.addEventListener("click", (e) => {
             if (this.viewModel) {
                 this._scrollManager.setNextUpdateIsSmooth();

--- a/browser/mainapp/src/components/ChannelStream.ts
+++ b/browser/mainapp/src/components/ChannelStream.ts
@@ -84,7 +84,7 @@ export class ChannelStream extends ComponentBase<ChannelViewModel> {
             const vm = currentScrollToVm;
             if (vm) {
                 if ((v ?? null) != vm.scrolledTo) {
-                    this.logger.logInfo("DefaultStreamScrollManager.scrolledTo change", v, vm.title);
+                    this.logger.logDebug("DefaultStreamScrollManager.scrolledTo change", v, vm.title);
                     if (v) {
                         vm.scrolledTo = v;
                     }
@@ -228,43 +228,63 @@ export class ChannelStream extends ComponentBase<ChannelViewModel> {
     private _previousCollapseHostRO: ResizeObserver | null = null;
     private _roAnimHandle: number | null = null;
     private _roAnimEntries: ResizeObserverEntry[] = [];
+    private readonly _previousCollapseHostROObserved: Set<Element> = new Set();
     updateCollapseHostMonitoring() {
+        this.logDebug("updateCollapseHostMonitoring");
         const vm = this.viewModel;
         const elMessageContainer = this.$("elMessageContainer") as HTMLDivElement;
 
-        if (this._previousCollapseHostRO) {
-            this._previousCollapseHostRO.disconnect();
-            this._previousCollapseHostRO = null;
+        if (!vm) {
+            if (this._previousCollapseHostRO) {
+                this._previousCollapseHostRO.disconnect();
+                this._previousCollapseHostRO = null;
+            }
+            this._previousCollapseHostROObserved.clear();
+            return;
         }
-        if (!vm) { return; }
 
-        const ro = new ResizeObserver(entries => {
-            this._roAnimEntries.push(...entries);
-            if (this._roAnimHandle == null) {
-                this._roAnimHandle = window.requestAnimationFrame(() => {
-                    this._roAnimHandle = null;
-                    const entries = this._roAnimEntries;
-                    this._roAnimEntries = [];
-                    for (let entry of entries) {
-                        const target = entry.target;
-                        if (target.classList.contains("messageitem")) {
-                            const mheight = entry.contentRect.height;
-                            if (mheight > 0) {
-                                const mvm = (target as any)["__vm"] as ChannelMessageViewModel;
-                                const overflowHeight = +(window.getComputedStyle(target).getPropertyValue("--ad-collapse-max-height-numeric") ?? "40");
-                                const isOversized = (mheight > overflowHeight);
-                                if (isOversized != mvm.isOversized) {
-                                    mvm.isOversized = (mheight > overflowHeight);
-                                    this.logger.logDebug("ad oversize changed", target, isOversized);
+        if (!this._previousCollapseHostRO) {
+            const ro = new ResizeObserver(entries => {
+                this._roAnimEntries.push(...entries);
+                if (this._roAnimHandle == null) {
+                    this._roAnimHandle = window.requestAnimationFrame(() => {
+                        this._roAnimHandle = null;
+                        const entries = this._roAnimEntries;
+                        this._roAnimEntries = [];
+                        let overflowHeight: number | null = null;
+                        for (let entry of entries) {
+                            const target = entry.target;
+                            if (target.classList.contains("messageitem")) {
+                                const mheight = entry.contentRect.height;
+                                if (mheight > 0) {
+                                    const mvm = (target as any)["__vm"] as ChannelMessageViewModel;
+                                    overflowHeight = overflowHeight ?? +(window.getComputedStyle(target).getPropertyValue("--ad-collapse-max-height-numeric") ?? "40");
+                                    const isOversized = (mheight > overflowHeight);
+                                    if (isOversized != mvm.isOversized) {
+                                        mvm.isOversized = (mheight > overflowHeight);
+                                        this.logger.logDebug("ad oversize changed", target, isOversized);
+                                    }
                                 }
                             }
                         }
-                    }
-                });
+                    });
+                }
+            });
+            this._previousCollapseHostRO = ro;
+        }
+
+        const tro = this._previousCollapseHostRO;
+        const thisObserve = new Set<Element>();
+        elMessageContainer.querySelectorAll(".collapse-host.collapsible .messageitem").forEach(el => { 
+            if (!this._previousCollapseHostROObserved.has(el)) {
+                tro.observe(el); 
             }
+            thisObserve.add(el);
         });
-        this._previousCollapseHostRO = ro;
-        elMessageContainer.querySelectorAll(".collapse-host.collapsible .messageitem").forEach(el => { ro.observe(el); });
+        for (let removeEl of [...this._previousCollapseHostROObserved.difference(thisObserve).values()]) {
+            tro.unobserve(removeEl);
+            this._previousCollapseHostROObserved.delete(removeEl);
+        }
     }
 
     protected get myRequiredStylesheets() {

--- a/browser/mainapp/src/components/ChatsList.tsx
+++ b/browser/mainapp/src/components/ChatsList.tsx
@@ -112,7 +112,7 @@ export class ChatsList extends RenderingComponentBase<ActiveLoginViewModel> {
             this.elMain.classList.toggle("has-alerts-below", elementsNotVisibleBelow.size > 0);
         };
         const recalculateAlertDisplay = () => {
-            this.logger.logInfo("recalculatingAlertDisplay");
+            this.logger.logDebug("recalculatingAlertDisplay");
             if (io) {
                 elementsNotVisibleAbove.clear();
                 elementsNotVisibleBelow.clear();
@@ -155,7 +155,7 @@ export class ChatsList extends RenderingComponentBase<ActiveLoginViewModel> {
                 hasAlertEls.forEach(el => {
                     io!.observe(el as HTMLElement);
                 });
-                this.logger.logInfo("recalculatingAlertDisplay watching element count", hasAlertEls.length);
+                this.logger.logDebug("recalculatingAlertDisplay watching element count", hasAlertEls.length);
             }
         };
         const scrollToNext = (map: Map<HTMLElement, number>, shouldTake: (curBound: number, maxBound: number) => boolean) => {

--- a/browser/mainapp/src/components/EIconDisplay.ts
+++ b/browser/mainapp/src/components/EIconDisplay.ts
@@ -1,15 +1,71 @@
+import { CharacterName } from "../shared/CharacterName";
+import { BBCodeParser } from "../util/bbcode/BBCode";
+import { CancellationTokenSource } from "../util/CancellationTokenSource";
+import { asDisposable, IDisposable } from "../util/Disposable";
+import { EIconLoadManager } from "../util/EIconLoadManager";
+import { EventListenerUtil } from "../util/EventListenerUtil";
 import { HTMLUtils } from "../util/HTMLUtils";
+import { Logging } from "../util/Logger";
+import { ObservableExpression } from "../util/ObservableExpression";
+import { setStylesheetAdoption } from "../util/StyleSheetPolyfill";
 import { URLUtils } from "../util/URLUtils";
-import { componentElement } from "./ComponentBase";
+import { WhenChangeManager } from "../util/WhenChange";
+import { AppViewModel } from "../viewmodel/AppViewModel";
+import { componentElement, StyleLoader } from "./ComponentBase";
+
+const emptyImageUrl = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+const io = new IntersectionObserver((entries) => {
+    for (let entry of entries) {
+        const ed = (entry.target as EIconDisplay);
+        ed.set_isIntersecting(entry.isIntersecting);
+    }
+});
 
 class EIconSyncManager {
+    private readonly _logger = Logging.createLogger("EIconSyncManager");
+
+    private _syncGroups: Map<string, Set<EIconDisplay>> = new Map();
+    private _eiconsToSyncGroup: Map<EIconDisplay, string> = new Map();
+
     add(ed: EIconDisplay, syncGroup: string) {
-        this.remove(ed);
-        // TODO:
+        let sg = this._syncGroups.get(syncGroup);
+        if (!sg) {
+            sg = new Set();
+            this._syncGroups.set(syncGroup, sg);
+        }
+        sg.add(ed);
+        this._eiconsToSyncGroup.set(ed, syncGroup);
     }
 
-    remove(ed: EIconDisplay) {
-        // TODO:
+    remove(ed: EIconDisplay, syncGroup: string) {
+        const sg = this._syncGroups.get(syncGroup);
+        if (sg) {
+            sg.delete(ed);
+            if (sg.size == 0) {
+                this._syncGroups.delete(syncGroup);
+            }
+        }
+        this._eiconsToSyncGroup.delete(ed);
+    }
+
+    indicateLoad(ed: EIconDisplay) {
+        const syncGroup = this._eiconsToSyncGroup.get(ed);
+        if (syncGroup) {
+            const sg = this._syncGroups.get(syncGroup);
+            if (sg) {
+                let allLoaded = true;
+                for (let xed of sg.values()) {
+                    allLoaded = allLoaded && xed.isImageLoaded && xed.isIntersecting;
+                }
+                if (allLoaded) {
+                    this._logger.logDebug("syncing eicon sync group", syncGroup);
+                    for (let xed of sg.values()) {
+                        xed.restartAnimation();
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -17,22 +73,40 @@ const eIconSyncManager = new EIconSyncManager();
 
 @componentElement("x-eicondisplay")
 export class EIconDisplay extends HTMLElement {
-    static get observedAttributes() { return [ 'eiconname', 'syncgroup' ] };
+    static get observedAttributes() { return [ 'eiconname', 'syncgroup', 'charname' ] };
 
     constructor() {
         super();
 
-        this._sroot = this.attachShadow({ mode: 'closed' });
-        HTMLUtils.assignStaticHTMLFragment(this._sroot, `
-            <link rel="stylesheet" type="text/css" href="styles/components/EIconDisplay.css" />
-            <div id="elMain">
-            </div>
-        `);
-        
+        // this._sroot = this.attachShadow({ mode: 'closed' });
+        // HTMLUtils.assignStaticHTMLFragment(this._sroot, `
+        //     <div id="elMain">
+        //     </div>
+        // `);
+    
+        // this._styleLoader = new StyleLoader(ss => {
+        //     //setStylesheetAdoption(this._sroot, ss);
+        //     //(this._sroot as any).adoptedStyleSheets = [...ss];
+        // });  
+        // this._styleLoader.addLoad("styles/components/EIconDisplay.css");
+
+        // this._sroot.addEventListener("copy", (e: ClipboardEvent) => {
+        //     BBCodeParser.performCopy(e);
+        // });
     }
 
-    private readonly _sroot: ShadowRoot;
-    private get elMain() { return this._sroot.getElementById("elMain") as HTMLDivElement; }
+    private readonly _logger = Logging.createLogger("EIconDisplay");
+
+    //private readonly _styleLoader: StyleLoader;
+
+    //private readonly _sroot: ShadowRoot;
+    //private get elMain() { return this._sroot.getElementById("elMain") as HTMLDivElement; }
+    private get elMain() { return this; }
+
+    private get imgEl() {
+        if (this.childElementCount == 0) { return null; }
+        return this.firstElementChild as HTMLImageElement;
+    }
 
     private attributeChangedCallback(name: string, oldValue?: string, newValue?: string) {
         if (name == "eiconname") {
@@ -40,6 +114,9 @@ export class EIconDisplay extends HTMLElement {
         }
         else if (name == "syncgroup") {
             this.syncGroup = newValue ?? null;
+        }
+        else if (name == "charname") {
+            this.charName = newValue ?? null;
         }
     }
 
@@ -49,6 +126,38 @@ export class EIconDisplay extends HTMLElement {
 
     private disconnectedCallback() {
         this.updateState();
+    }
+
+    private _isIntersecting: boolean = false;
+    get isIntersecting() { return this._isIntersecting; }
+    set_isIntersecting(value: boolean) {
+        if (value !== this._isIntersecting) {
+            this._isIntersecting = value;
+            this._logger.logDebug("eicon intersecting", this.eiconName, value);
+            this.updateState();
+        }
+    }
+
+    private _isImageLoaded: boolean = false;
+    get isImageLoaded() { return this._isImageLoaded; }
+    private set_isImageLoaded(value: boolean) {
+        if (value !== this._isImageLoaded) {
+            this._isImageLoaded = value;
+            this.updateState();
+        }
+    }
+
+    get charName() { return this.getAttribute("charname") ?? null; }
+    set charName(value: string | null) {
+        if (value !== this.charName) {
+            if (value) {
+                this.setAttribute("charname", value);
+            }
+            else {
+                this.removeAttribute("charname");
+            }
+            this.updateState();
+        }
     }
 
     get syncGroup() { return this.getAttribute("syncgroup") ?? null; }
@@ -79,44 +188,134 @@ export class EIconDisplay extends HTMLElement {
         }
     }
 
+    restartAnimation() {
+        const imgEl = this.imgEl;
+        if (imgEl) {
+            imgEl.src = imgEl.src;
+        }
+    }
+
+    private _appViewModelHookup: IDisposable | null = null;
+
+    private _stopPreviousEIconLoad: (() => void) = () => {};
+
     private _lastStateEIconName: string | null = null;
     private _lastStateIsConnected: boolean = false;
     private _lastStateSyncGroup: string | null = null;
+    private _lastIsCompletedLoaded = false;
+    private _isInIntersectObserver = false;
+
+    private _eiconBlockWCM: WhenChangeManager = new WhenChangeManager();
+
     updateState() {
         const lastEIconName = this._lastStateEIconName;
         const lastIsConnected = this._lastStateIsConnected;
         const lastSyncGroup = this._lastStateSyncGroup;
+
         const isConnected = this.isConnected;
         const eiconName = this.eiconName;
         const syncGroup = isConnected ? this.syncGroup : null;
+        const charName = this.charName ? CharacterName.create(this.charName) : null;
 
         this._lastStateEIconName = eiconName;
         this._lastStateIsConnected = isConnected;
         this._lastStateSyncGroup = syncGroup;
 
-        let imgEl = this._sroot.getElementById("imgEl") as (HTMLImageElement | null);
-
-        if (eiconName != lastEIconName) {
-            if (eiconName) {
-                if (!imgEl) {
-                    imgEl = document.createElement("img");
-                    this.elMain.appendChild(imgEl);
-                }
-                imgEl.src = URLUtils.getEIconUrl(eiconName, syncGroup);
-            }
-            else {
-                if (imgEl) {
-                    imgEl.remove();
-                }
-            }
-        }
+        let imgEl = this.imgEl;
 
         if (syncGroup != lastSyncGroup) {
             if (syncGroup) {
                 eIconSyncManager.add(this, syncGroup);
             }
             else {
-                eIconSyncManager.remove(this);
+                if (lastSyncGroup) {
+                    eIconSyncManager.remove(this, lastSyncGroup);
+                }
+            }
+        }
+
+        this._eiconBlockWCM.assign<[CharacterName | null, string | null]>((isConnected && charName && eiconName) ? [charName, eiconName] : [null, null],
+            v => {
+                const charName = v[0];
+                const eiconName = v[1];
+                if (charName && eiconName) {
+                    const isBlockedObs = new ObservableExpression(
+                        () => {
+                            for (let login of ((window as any)["__vm"] as AppViewModel).logins) {
+                                if (login.characterName == charName) {
+                                    return login.eIconFavoriteBlockViewModel.isBlocked(eiconName);
+                                }
+                            }
+                            return false;
+                        },
+                        (isBlocked) => { imgEl?.classList.toggle("blocked", isBlocked); },
+                        () => { imgEl?.classList.toggle("blocked", false); }
+                    );
+                    return asDisposable(isBlockedObs);
+                }
+            });
+
+        if (isConnected) {
+            if (!this._isInIntersectObserver) {
+                this._isInIntersectObserver = true;
+                io.observe(this);
+            }
+
+            if (eiconName != lastEIconName || syncGroup != lastSyncGroup) {
+                this._stopPreviousEIconLoad();
+
+                if (eiconName) {
+                    if (!imgEl) {
+                        imgEl = document.createElement("img");
+                        imgEl.id = "imgEl";
+                        imgEl.src = emptyImageUrl;
+                        imgEl.setAttribute("data-copycontent", `[eicon]${eiconName}[/eicon]`);
+                        this.elMain.appendChild(imgEl);
+                    }
+
+                    const cts = new CancellationTokenSource();
+                    this._stopPreviousEIconLoad = () => cts.cancel();
+                    (async () => {
+                        try {
+                            const loadedEicon = EIconLoadManager.getEIcon(eiconName);
+                            const blobUrl = await loadedEicon.getBlobUrlAsync(syncGroup ?? "", cts.token);
+                            this._stopPreviousEIconLoad = () => {
+                                blobUrl.dispose();
+                                imgEl!.src = emptyImageUrl;
+                            };
+                            const loadHandler = EventListenerUtil.addDisposableEventListener(imgEl, "load", () => {
+                                loadHandler.dispose();
+                                this._logger.logDebug("eicon load", eiconName);
+                                this.set_isImageLoaded(true);
+                            });
+                            imgEl.src = blobUrl.url;
+                        }
+                        catch { }
+                    })();
+                }
+            }
+
+            if (this.isImageLoaded && this.isIntersecting && !this._lastIsCompletedLoaded) {
+                this._lastIsCompletedLoaded = true;
+                this._logger.logDebug("indicating eicon load sync", eiconName);
+                eIconSyncManager.indicateLoad(this);
+            }
+            else {
+                this._lastIsCompletedLoaded = false;
+            }
+        }
+        else {
+            this._stopPreviousEIconLoad();
+
+            this._lastIsCompletedLoaded = false;
+            if (this._appViewModelHookup) {
+                this._appViewModelHookup.dispose();
+                this._appViewModelHookup = null;
+            }
+            
+            if (this._isInIntersectObserver) {
+                this._isInIntersectObserver = false;
+                io.unobserve(this);
             }
         }
     }

--- a/browser/mainapp/src/components/LogSearchDateInput.ts
+++ b/browser/mainapp/src/components/LogSearchDateInput.ts
@@ -1,12 +1,14 @@
 import { FastEventSource } from "../util/FastEventSource";
 import { HTMLUtils } from "../util/HTMLUtils";
+import { StringUtils } from "../util/StringUtils";
 import { setStylesheetAdoption } from "../util/StyleSheetPolyfill";
 import { AppViewModel } from "../viewmodel/AppViewModel";
+import { LocaleViewModel } from "../viewmodel/LocaleViewModel";
 import { LogSearchDate, SearchDate } from "../viewmodel/LogSearchViewModel";
 //import { LogSearchDateSelectionPopupViewModel } from "../viewmodel/popups/LogSearchDateSelectionPopupViewModel";
 import { StyleLoader, componentElement } from "./ComponentBase";
 
-const dtfWithDate = new Intl.DateTimeFormat(undefined, { dateStyle: "long", timeStyle: "long" });
+//const dtfWithDate = new Intl.DateTimeFormat(undefined, { dateStyle: "long", timeStyle: "long" });
 
 @componentElement("x-logsearchdateinput")
 export class LogSearchDateInput extends HTMLElement {
@@ -30,7 +32,7 @@ export class LogSearchDateInput extends HTMLElement {
             this.elButton.style.removeProperty("display");
         })();
 
-        this.elDateText.innerText = this.dateToString(new Date());
+        this.elDateText.innerText = this.dateToString(LocaleViewModel.default, new Date());
         this.elButton.addEventListener("click", async () => {
             this.elButton.classList.toggle("popupshown", true);
             try {
@@ -66,25 +68,25 @@ export class LogSearchDateInput extends HTMLElement {
     set value(v: LogSearchDate) { 
         if (v != this._value) {
             this._value = v;
-            this.onValueChanged(v);
+            this.onValueChanged(this.appViewModel?.locale ?? LocaleViewModel.default, v);
         }
     }
 
-    private onValueChanged(v: LogSearchDate) {
+    private onValueChanged(locale: LocaleViewModel, v: LogSearchDate) {
         const elButton = this.elButton;
         const vIsDate = v instanceof Date;
 
         elButton.classList.toggle("nowtext", (v === SearchDate.Now));
         elButton.classList.toggle("datetext", vIsDate);
         if (vIsDate) {
-            this.elDateText.innerText = this.dateToString(v);
+            this.elDateText.innerText = this.dateToString(locale, v);
         }
 
         this.dispatchEvent(new Event("valuechanged"));
     }
 
-    private dateToString(dt: Date) {
-        const result = dtfWithDate.format(dt);
+    private dateToString(locale: LocaleViewModel, dt: Date) {
+        const result = StringUtils.dateToString(locale, dt, { dateStyle: "long", timeStyle: "long" });
         return result;
     }
 

--- a/browser/mainapp/src/components/dialogs/character-profile/CharacterGuestbookPane.tsx
+++ b/browser/mainapp/src/components/dialogs/character-profile/CharacterGuestbookPane.tsx
@@ -45,6 +45,8 @@ export class CharacterGuestbookPane extends RenderingComponentBase<CharacterGues
     renderGuestbookPosts(vm: CharacterGuestbookViewModel): VNode[] {
         const result: VNode[] = [];
 
+        const locale = vm.session.appViewModel.locale;
+
         this._parseOptionsWCM.assign({ sink: vm.session.bbcodeSink, appViewModel: vm.session.appViewModel, session: vm.session },
             (v) => {
                 this._bbcodeParseOptions = {
@@ -69,7 +71,7 @@ export class CharacterGuestbookPane extends RenderingComponentBase<CharacterGues
                 <div classList="guestbook-post-info">
                     <img classList="guestbook-poster-image" attr-src={URLUtils.getAvatarImageUrl(post.character)}></img>
                     <div classList={["guestbook-poster-name"]}><b>{posterChar}</b></div>
-                    <div classList="guestbook-datetime">Posted <span>{StringUtils.dateToString(post.postedAt, { dateStyle: "long", timeStyle: "short" })}</span></div>
+                    <div classList="guestbook-datetime">Posted <span>{StringUtils.dateToString(locale, post.postedAt, { dateStyle: "long", timeStyle: "short" })}</span></div>
                 </div>
                 <div classList="guestbook-message"><x-bbcodedisplay props={{ "viewModel": post.message, parseOptions: po, parser: "profilenoimg" }} ></x-bbcodedisplay></div>
                 { hasReply 

--- a/browser/mainapp/src/configuration/ConfigSchemaItem.ts
+++ b/browser/mainapp/src/configuration/ConfigSchemaItem.ts
@@ -1,5 +1,7 @@
 import { ChannelName } from "../shared/ChannelName";
 import { CharacterName } from "../shared/CharacterName";
+import { CancellationToken } from "../util/CancellationTokenSource";
+import { HostInterop } from "../util/HostInterop";
 import { IterableUtils } from "../util/IterableUtils";
 
 export interface ConfigSchemaDefinition {
@@ -129,6 +131,19 @@ function generateNumericOptions(min: number, max: number): ConfigSchemaSelectOpt
     return results;
 }
 
+const spellCheckLanguageItem: ConfigSchemaItemDefinitionItem = {
+    id: "spellCheckLanguage",
+    scope: getScopeArray(["global"]),
+    title: "Spell Check Language",
+    description: "Which language should be used to check spelling? (Changes to this setting require a restart of XarChat)",
+    type: "select",
+    selectOptions: [
+        { value: "default", displayValue: "System Default" }
+    ],
+    defaultValue: 0,
+    configBlockKey: "spellCheckLanguage"
+};
+
 export const ConfigSchema: ConfigSchemaDefinition = {
     settings: [
         {
@@ -155,6 +170,7 @@ export const ConfigSchema: ConfigSchemaDefinition = {
                     defaultValue: true,
                     configBlockKey: "useGpuAcceleration"
                 },
+                spellCheckLanguageItem,
                 {
                     id: "autoReconnect",
                     scope: getScopeArray(["global", "char"]),
@@ -1347,3 +1363,10 @@ export function getConfigSchemaItemById(id: string): ConfigSchemaItemDefinitionI
         return result;
     }
 }
+
+(async () => {
+    const locales = await HostInterop.getAvailableLocales(CancellationToken.NONE);
+    for (let l of locales) {
+        spellCheckLanguageItem.selectOptions?.push({ value: l.code, displayValue: l.name });
+    }
+})();

--- a/browser/mainapp/src/configuration/ConfigSchemaItem.ts
+++ b/browser/mainapp/src/configuration/ConfigSchemaItem.ts
@@ -192,6 +192,20 @@ export const ConfigSchema: ConfigSchemaDefinition = {
                     configBlockKey: "eiconSearch.enabled"
                 },
                 {
+                    id: "openPmTabForIncomingTyping",
+                    scope: getScopeArray(["global"]),
+                    title: "Open a PM Tab on Typing",
+                    description: "Should XarChat open a PM tab (if you don't have one already open) when someone starts typing a private message to you?",
+                    type: "select",
+                    selectOptions: [
+                        { value: 0, displayValue: "No" },
+                        { value: 1, displayValue: "Yes" },
+                        { value: 2, displayValue: "Yes and Ping" },
+                    ],
+                    defaultValue: 0,
+                    configBlockKey: "openPmTabForIncomingTyping.enabled"
+                },                
+                {
                     scope: getScopeArray(["global"]),
                     sectionTitle: "Auto Idle/Away",
                     items: [

--- a/browser/mainapp/src/configuration/ConfigSchemaItem.ts
+++ b/browser/mainapp/src/configuration/ConfigSchemaItem.ts
@@ -809,6 +809,44 @@ export const ConfigSchema: ConfigSchemaDefinition = {
                 },
                 {
                     scope: getScopeArray(["global"]),
+                    sectionTitle: "Locale",
+                    description: "Configure localization settings for XarChat.",
+                    items: [
+                        {
+                            id: "locale.dateFormat",
+                            scope: getScopeArray(["global"]),
+                            title: "Date Formatting",
+                            description: "Select the format used for displaying dates.",
+                            type: "select",
+                            selectOptions: [
+                                { value: "default", displayValue: "Use Auto-Detected Setting" },
+                                { value: "mdyyyy", displayValue: "M/D/YYYY" },
+                                { value: "mmddyyyy", displayValue: "MM/DD/YYYY" },
+                                { value: "dmyyyy", displayValue: "D/M/YYYY" },
+                                { value: "ddmmyyyy", displayValue: "DD/MM/YYYY" },
+                                { value: "yyyymmdd", displayValue: "YYYY/MM/DD" }
+                            ],
+                            defaultValue: "default",
+                            configBlockKey: "locale.dateFormat"
+                        },
+                        {
+                            id: "locale.timeFormat",
+                            scope: getScopeArray(["global"]),
+                            title: "Time Formatting",
+                            description: "Select the format used for displaying times.",
+                            type: "select",
+                            selectOptions: [
+                                { value: "default", displayValue: "Use Auto-Detected Setting" },
+                                { value: "12h", displayValue: "12 Hour (AM/PM)" },
+                                { value: "24h", displayValue: "24 Hour" }
+                            ],
+                            defaultValue: "default",
+                            configBlockKey: "locale.timeFormat"
+                        },
+                    ]
+                },
+                {
+                    scope: getScopeArray(["global"]),
                     sectionTitle: "Colors",
                     description: "Choose colors for various parts of the XarChat interface.",
                     items: [

--- a/browser/mainapp/src/main.ts
+++ b/browser/mainapp/src/main.ts
@@ -1,29 +1,17 @@
-import { ChatViewModelSink } from "./ChatViewModelSink.js";
-import { ComponentBase, StyleLoader } from "./components/ComponentBase.js";
+import { StyleLoader } from "./components/ComponentBase.js";
 import { MainInterface } from "./components/MainInterface.js";
-import { ChatConnectionFactory, NullChatConnection } from "./fchat/ChatConnectionFactory.js";
-import { ChannelMessageData } from "./fchat/ChatConnectionSink.js";
-import { ChannelName } from "./shared/ChannelName.js";
-import { CharacterGender, CharacterGenderConvert } from "./shared/CharacterGender.js";
-import { CharacterName } from "./shared/CharacterName.js";
-import { OnlineStatus, OnlineStatusConvert } from "./shared/OnlineStatus.js";
-import { TypingStatus } from "./shared/TypingStatus.js";
-import { CancellationToken } from "./util/CancellationTokenSource.js";
 import { HostInteropConfigBlock } from "./util/ConfigBlock.js";
 import { HostInterop } from "./util/HostInterop.js";
 import { KeyCodes } from "./util/KeyCodes.js";
-import { ObservableBase } from "./util/ObservableBase.js";
 import { hookRequestAnimationFrame } from "./util/RequestAnimationFrameHook.js";
 import { polyfillRequestIdleCallback } from "./util/RequestIdleCallbackPolyfill.js";
-import { setStylesheetAdoption } from "./util/StyleSheetPolyfill.js";
+import { setStylesheetAdoption, SharedStyleSheet } from "./util/StyleSheetPolyfill.js";
 import { XarChatUtils } from "./util/XarChatUtils.js";
-import { ActiveLoginViewModel } from "./viewmodel/ActiveLoginViewModel.js";
 import { AppViewModel } from "./viewmodel/AppViewModel.js";
-import { ChannelMessageViewModel, ChannelViewModel } from "./viewmodel/ChannelViewModel.js";
-import { ChatChannelViewModel } from "./viewmodel/ChatChannelViewModel.js";
 import { AppInitializeViewModel } from "./viewmodel/dialogs/AppInitializeViewModel.js";
-import { LoginViewModel } from "./viewmodel/dialogs/LoginViewModel.js";
+import { registerDebuggingFunctions } from "./util/debugging/DebugUtils.js";
 
+registerDebuggingFunctions();
 
 hookRequestAnimationFrame();
 
@@ -34,44 +22,6 @@ function onReady(func: Function) {
     else {
         document.addEventListener("DOMContentLoaded", () => func());
     }
-}
-
-function runChannelChatting(ch: ChatChannelViewModel) {
-    // let i = 0;
-    // window.setInterval(() => {
-    //     ch.addChatMessage(new Date(), CharacterName.create("Xariah Dailstone"), `This is message for ${ch.title} #${i++}`);
-    // }, 300);
-}
-
-function runStatusSetting(vm: ActiveLoginViewModel) {
-    // window.setInterval(() => {
-    //     vm.characterSet.setCharacterStatus(CharacterName.create("Xariah Dailstone"), {
-    //         gender: CharacterGenderConvert.getRandom(),
-    //         status: OnlineStatusConvert.getRandom()
-    //     });
-    // }, 750);
-}
-
-function createTestButton(vm: AppViewModel) {
-    const btn = document.createElement("button");
-    btn.style.position = "absolute";
-    btn.style.top = "10px";
-    btn.style.left = "10px";
-    btn.style.zIndex = "99999999";
-    btn.innerText = "test";
-
-    btn.addEventListener("click", () => {
-        // const builder = [];
-        // for (let i = 0; i < 500; i++) {
-        //     builder.push(`this is a test alert ${i}`);
-        // }
-        // vm.alertAsync(builder.join(""), "title");
-
-        const ld = new LoginViewModel(vm);
-        vm.showDialogAsync(ld);
-    });
-
-    document.body.appendChild(btn);
 }
 
 function setClientVersionData() {
@@ -134,8 +84,7 @@ onReady(async () => {
     for (let f of allCssFiles) {
         await StyleLoader.loadAsync(f);
     }
-    const customCssStlyesheet = await StyleLoader.loadAsync("/customcss");
-    setStylesheetAdoption(document, [customCssStlyesheet]);
+    
     loadDarkThemeCss();
 
     const p = new URLSearchParams(document.location.search);
@@ -149,7 +98,6 @@ onReady(async () => {
 
     let vm = new AppViewModel(cb);
     (window as any)["__vm"] = vm;
-    //vm.pingWords = [ "xariah" ];
 
     HostInterop.registerWindowBoundsChangeCallback((loc) => {
         vm.applicationWindowMoved(loc);
@@ -194,9 +142,9 @@ document.addEventListener("keydown", (e) => {
 });
 
 async function loadDarkThemeCss() {
-    var sss = await StyleLoader.loadAsync("styles/dark-theme.css");
-    var sss2 = await StyleLoader.loadAsync("styles/bbcode.css");
-    setStylesheetAdoption(document, [sss, sss2]);
+    const sss = await StyleLoader.loadAsync("styles/dark-theme.css");
+    const sss2 = await StyleLoader.loadAsync("styles/bbcode.css");
+    const customCssStlyesheet = await StyleLoader.loadAsync("/customcss");
+    setStylesheetAdoption(document, [sss, sss2, customCssStlyesheet]);
     document.getElementById("elLinkDarkTheme")?.remove();
-    //throw new Error("Function not implemented.");
 }

--- a/browser/mainapp/src/util/DelayedCallManager.ts
+++ b/browser/mainapp/src/util/DelayedCallManager.ts
@@ -50,6 +50,13 @@ export class DelayedCallManager {
                     this._isScheduled = true;
                 }
                 break;
+            case DelayedCallScheduler.SET_TIMEOUT_1MS:
+                {
+                    const n = window.setTimeout(() => this.runDelayedCall(), 1);
+                    this._unscheduleFunc = () => window.clearTimeout(n);
+                    this._isScheduled = true;
+                }
+                break;
         }
     }
 
@@ -77,5 +84,6 @@ export enum DelayedCallStyle {
 }
 
 export enum DelayedCallScheduler {
-    REQUEST_ANIMATION_FRAME
+    REQUEST_ANIMATION_FRAME,
+    SET_TIMEOUT_1MS
 }

--- a/browser/mainapp/src/util/FocusMagnet.ts
+++ b/browser/mainapp/src/util/FocusMagnet.ts
@@ -14,17 +14,11 @@ export class FocusMagnet {
     constructor() {
         this.logger = Logging.createLogger(`FocusMagnet#${ObjectUniqueId.get(this)}`);
 
-        document.addEventListener("focus", (e) => { 
-            //this.logger.logDebug("focusmanager document.focus", e.target);
-            this.ultimateFocus = this.drillDown(e.target as Element);
-        }, { capture: true });
-        document.addEventListener("blur", (e) => {
-            //this.logger.logDebug("focusmanager document.blur", e.target);
-            this.ultimateFocus = null;
-        }, { capture: true });
-
-        // document.addEventListener("selectionchange", (e) => {
-        //     this.logger.logDebug("focusmanager document.selectionchange", e.target);
+        // document.addEventListener("focus", (e) => { 
+        //     this.ultimateFocus = this.drillDown(e.target as Element);
+        // }, { capture: true });
+        // document.addEventListener("blur", (e) => {
+        //     this.ultimateFocus = null;
         // }, { capture: true });
     }
 

--- a/browser/mainapp/src/util/HostInterop.ts
+++ b/browser/mainapp/src/util/HostInterop.ts
@@ -859,7 +859,7 @@ class XarHost2Interop implements IXarHost2HostInterop {
             hasPings: hasPings,
             hasUnseen: hasUnseen
         };
-        this.logger.logInfo("updateAppBadge", this._lastAppBadgeAssign);
+        this.logger.logDebug("updateAppBadge", this._lastAppBadgeAssign);
         this.writeToXCHostSocket("updateAppBadge " + JSON.stringify(this._lastAppBadgeAssign));
     }
 

--- a/browser/mainapp/src/util/StringUtils.ts
+++ b/browser/mainapp/src/util/StringUtils.ts
@@ -1,6 +1,7 @@
+import { DateFormatSpecifier, LocaleViewModel, TimeFormatSpecifier } from "../viewmodel/LocaleViewModel";
 import { Optional } from "./Optional";
 
-const intlDTFCache: Map<string, Intl.DateTimeFormat> = new Map();
+//const intlDTFCache: Map<string, Intl.DateTimeFormat> = new Map();
 const intlNFCache: Map<string, Intl.NumberFormat> = new Map();
 
 let confusablesMap: Map<string, string> | undefined = undefined;
@@ -28,20 +29,30 @@ export class StringUtils {
         return false;
     }
 
+    static makeTwoDigitString(n: number) {
+        let res = n.toString();
+        if (res.length == 1) {
+            return "0" + res;
+        }
+        else {
+            return res;
+        }
+    }
+
     static discardUnseen(str: string) {
         const xstr = [...str];
         return xstr.join("");
     }
 
-    static dateToString(date: Date, formatting: Intl.DateTimeFormatOptions) {
-        const key = JSON.stringify(formatting);
-        let v = intlDTFCache.get(key);
-        if (!v) {
-            v = new Intl.DateTimeFormat(undefined, formatting);
-            intlDTFCache.set(key, v);
+    static dateToString(locale: LocaleViewModel, date: Date, formatting: { dateStyle?: DateFormatSpecifier, timeStyle?: TimeFormatSpecifier }) {
+        const sb: string[] = [];
+        if (formatting.dateStyle) {
+            sb.push(locale.getDateString(date, formatting.dateStyle));
         }
-        const result = v.format(date);
-        return result;
+        if (formatting.timeStyle) {
+            sb.push(locale.getTimeString(date, formatting.timeStyle));
+        }
+        return sb.join(" ");
     }
 
     static numberToString(num: number, formatting: Intl.NumberFormatOptions) {

--- a/browser/mainapp/src/util/bbcode/tags/BBCodeTagEIcon.ts
+++ b/browser/mainapp/src/util/bbcode/tags/BBCodeTagEIcon.ts
@@ -7,45 +7,6 @@ import { URLUtils } from "../../URLUtils";
 import { BBCodeParseContext, getContentText } from "../BBCode";
 import { BBCodeTag } from "../BBCodeTag";
 
-let emptyImageUrl = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-let emptyImageImg = EL("img", { src: emptyImageUrl });
-(async function () {
-    const emptyImageBlob = await (await fetch(emptyImageUrl)).blob();
-    const url = URL.createObjectURL(emptyImageBlob);
-    emptyImageUrl = url;
-    emptyImageImg.src = url;
-})();
-
-export const syncGifs = (raisingEl: HTMLElement, context: BBCodeParseContext) => {
-    let tel: (HTMLElement | null) = raisingEl;
-    while (tel) {
-        if (tel.classList.contains("bbcode-parsed")) {
-            let allLoaded = true;
-            const loadableEls =  tel.querySelectorAll("*[data-loaded]");
-            if (loadableEls.length > 1) {
-                const q = loadableEls.forEach(x => allLoaded = allLoaded && !!x.getAttribute("data-loaded"));
-                if (allLoaded) {
-                    for (let i = 0; i < loadableEls.length; i++) {
-                        const reloadEl = (loadableEls.item(i) as HTMLImageElement);
-                        if (!(reloadEl as any).__reloadedThisFrame) {
-                            const tsrc = reloadEl.src;
-                            reloadEl.src = '';
-                            reloadEl.src = tsrc;
-                            //context.lateElementUpdate();
-                            (reloadEl as any).__reloadedThisFrame = true;
-                            window.requestAnimationFrame(() => {
-                                delete (reloadEl as any).__reloadedThisFrame;
-                            });
-                        }
-                    }
-                }
-            }
-            break;
-        }
-        tel = tel.parentElement;
-    }
-};
-
 let nextUniqueId = 1;
 export const BBCodeTagEIcon = new BBCodeTag("eicon", true, false, 
     (context, arg, content) => {
@@ -55,154 +16,22 @@ export const BBCodeTagEIcon = new BBCodeTag("eicon", true, false,
             return document.createTextNode(content.rawOpenTag + contentText);
         }
 
-        let loadedEicon: LoadedEIcon | null = EIconLoadManager.getEIcon(contentText);
-
-        const loadContentCTS = new CancellationTokenSource();
-
-        const el = EL("img", {
+        const el = EL("x-eicondisplay", {
             class: "bbcode-eicon",
             title: arg ? `${contentText}\n@${arg}` : contentText,
-            src: emptyImageUrl,
-            "data-eicon": contentText,
+            eiconname: contentText,
+            charname: context.parseOptions.activeLoginViewModel?.characterName.canonicalValue,
             "data-copycontent": `${content.rawOpenTag}${contentText}${content.rawCloseTag}`
         });
-        el.classList.add("bbcode-eicon-loading");
+        
         if (context.parseOptions.syncGifs) {
-            el.setAttribute("data-loaded", "false");
+            if (!(context.parseOptions as any)["__syncgroup"]) {
+                (context.parseOptions as any)["__syncgroup"] = `syncgroup${nextUniqueId++}`;
+            }
+            el.setAttribute("syncgroup", (context.parseOptions as any)["__syncgroup"]);
         }
-        context.addDisposable(() => {
-            loadContentCTS.cancel();
-            loadedEicon = null;
-        });
+
         context.addUsedEIcon(contentText);
-
-        loadedEicon.getBlobUrlAsync(
-            (context.parseOptions.eiconsUniqueLoadTag 
-                ? context.parseOptions.eiconsUniqueLoadTag.replace("#", (nextUniqueId++).toString()) 
-                : ""),
-            loadContentCTS.token).then(
-                (b) => {
-                    el.addEventListener("load", (e) => {
-                        if ((e.target as HTMLImageElement).src != emptyImageUrl) {
-                            el.classList.remove("bbcode-eicon-loading");
-                            //context.lateElementUpdate();
-                        }
-                    });
-                    el.addEventListener("error", (e) => {
-                        if ((e.target as HTMLImageElement).src != emptyImageUrl) {
-                            el.classList.remove("bbcode-eicon-loading");
-                            el.classList.add("bbcode-eicon-failedtoload");
-                            //context.lateElementUpdate();
-                        }
-                    });
-
-                    if (context.parseOptions.syncGifs) {
-                        const lhandler = EventListenerUtil.addDisposableEventListener(el, "load", (e: Event) => {
-                            if ((e.target as HTMLImageElement).src != emptyImageUrl) {
-                                lhandler.dispose();
-                                el.setAttribute("data-loaded", "true");
-                                //context.lateElementUpdate();
-                                syncGifs(el, context);
-                            }
-                        });
-            
-                        let isIntersecting: (boolean | null) = null;
-                        const intersectObserver = new IntersectionObserver((entries) => {
-                            for (let e of entries) {
-                                if (e.target == el) {
-                                    if (e.isIntersecting) {
-                                        if (isIntersecting == null || isIntersecting == false) {
-                                            syncGifs(el, context);
-                                        }
-                                        isIntersecting = e.isIntersecting;
-                                    }
-                                }
-                            }
-                        });
-                        intersectObserver.observe(el);
-                        context.addDisposable(() => {
-                            intersectObserver.disconnect();
-                        });
-                    }
-
-                    el.src = b.url;
-                    context.addDisposable(b);
-                    //context.lateElementUpdate();
-                },
-                () => {
-                    el.classList.remove("bbcode-eicon-loading");
-                    el.classList.add("bbcode-eicon-failedtoload");
-                    el.classList.add("bbcode-eicon-failedtoload-b");
-                    //context.lateElementUpdate();
-                }
-            );
-
-        // const url = URLUtils.getEIconUrl(contentText, context.parseOptions.eiconsUniqueLoadTag 
-        //     ? context.parseOptions.eiconsUniqueLoadTag.replace("#", (nextUniqueId++).toString()) 
-        //     : null);
-
-        // let persistentImg: (HTMLImageElement | null) = EL("img", { src: url });
-        // context.disposables.push(asDisposable(() => {
-        //     persistentImg = null;
-        // }));
-
-        // let el: HTMLImageElement;
-        // if (arg) {
-        //     el = EL("img", { 
-        //         class: "bbcode-eicon", 
-        //         title: `${contentText}\n@${arg}`
-        //     });
-        // }
-        // else {
-        //     el = EL("img", { 
-        //         class: "bbcode-eicon", 
-        //         title: contentText
-        //     });
-        // }
-        // el.setAttribute("data-copycontent", `${content.rawOpenTag}${contentText}${content.rawCloseTag}`);
-
-        // if (context.parseOptions.syncGifs) {
-        //     el.setAttribute("data-loaded", "false");
-        //     const lhandler = EventListenerUtil.addDisposableEventListener(el, "load", () => {
-        //         lhandler.dispose();
-        //         el.setAttribute("data-loaded", "true");
-        //         syncGifs(el);
-        //     });
-
-        //     let isIntersecting: (boolean | null) = null;
-        //     const intersectObserver = new IntersectionObserver((entries) => {
-        //         for (let e of entries) {
-        //             if (e.target == el) {
-        //                 if (e.isIntersecting) {
-        //                     if (isIntersecting == null || isIntersecting == false) {
-        //                         syncGifs(el);
-        //                     }
-        //                     isIntersecting = e.isIntersecting;
-        //                 }
-        //             }
-        //         }
-        //     });
-        //     intersectObserver.observe(el);
-        //     context.disposables.push(
-        //         asDisposable(() => {
-        //             intersectObserver.disconnect();
-        //         })
-        //     );
-        // }
-
-        // el.classList.add("bbcode-eicon-loading");
-        // el.addEventListener("load", () => {
-        //     el.classList.remove("bbcode-eicon-loading");
-        // });
-        // el.addEventListener("error", () => {
-        //     el.classList.remove("bbcode-eicon-loading");
-        //     el.classList.remove("bbcode-eicon-failedtoload");
-        // });
-
-        // el.setAttribute("src", url);
-
+        
         return el;
-
-        //return EL("div", { class: "bbcode-eicon-outershell", "data-copyinline": "true" }, [ el ]);
-
     });

--- a/browser/mainapp/src/util/debugging/DebugUtils.ts
+++ b/browser/mainapp/src/util/debugging/DebugUtils.ts
@@ -1,0 +1,73 @@
+import { HTMLUtils } from "../HTMLUtils";
+
+function getElementSnapshot(sb: string[], el: Element) {
+    sb.push("<");
+    sb.push(el.tagName);
+    if (el.attributes.length > 0) {
+        for (let i = 0; i < el.attributes.length; i++) {
+            const attr = el.attributes.item(i);
+            if (attr) {
+                sb.push(' ');
+                sb.push(attr.name)
+                if (attr.value) {
+                    sb.push('="');
+                    sb.push(HTMLUtils.escapeHTML(attr.value));
+                    sb.push('"');
+                }
+            }
+        }
+    }
+    sb.push(">");
+
+    if ((el as any)._sroot) {
+        sb.push("<#SROOT ");
+        getNodeSnapshot(sb, (el as any)._sroot);
+        sb.push("#>");
+    }
+
+    if (el.childNodes.length > 0) {
+        for (let i = 0; i < el.childNodes.length; i++) {
+            getNodeSnapshot(sb, el.childNodes[i]);
+        }
+    }
+    sb.push("</");
+    sb.push(el.tagName);
+    sb.push(">");
+}
+
+function getCommentSnapshot(sb: string[], el: Node) {
+    sb.push("<!--" + el.nodeValue + "-->");
+}
+
+function getTextSnapshot(sb: string[], el: Node) {
+    sb.push(HTMLUtils.escapeHTML(el.nodeValue ?? ""));
+}
+
+function getDocumentFragmentSnapshot(sb: string[], el: DocumentFragment) {
+    for (var i = 0; i < el.childNodes.length; i++) {
+        getNodeSnapshot(sb, el.childNodes.item(i));
+    }
+}
+
+function getNodeSnapshot(sb: string[], el: Node) {
+    switch (el.nodeType) {
+        case Node.ELEMENT_NODE:
+            getElementSnapshot(sb, el as Element);
+            break;
+        case Node.COMMENT_NODE:
+            getCommentSnapshot(sb, el);
+            break;
+        case Node.TEXT_NODE:
+            getTextSnapshot(sb, el)
+            break;
+        case Node.DOCUMENT_FRAGMENT_NODE:
+            getDocumentFragmentSnapshot(sb, el as DocumentFragment);
+            break;
+    }
+}
+
+export function registerDebuggingFunctions() {
+    (window as any)["__debug"] = {
+        getNodeSnapshot: getNodeSnapshot
+    }
+}

--- a/browser/mainapp/src/viewmodel/AppViewModel.ts
+++ b/browser/mainapp/src/viewmodel/AppViewModel.ts
@@ -6,18 +6,22 @@ import { RawSavedWindowLocation } from "../settings/RawAppSettings.js";
 import { ChannelName } from "../shared/ChannelName.js";
 import { CharacterName } from "../shared/CharacterName.js";
 import { ConfigBlock } from "../util/ConfigBlock.js";
+import { IDisposable } from "../util/Disposable.js";
 import { HostInterop, HostWindowState } from "../util/HostInterop.js";
 import { IdleDetection, IdleDetectionScreenState, IdleDetectionUserState } from "../util/IdleDetection.js";
 import { Observable, ObservableValue, PropertyChangeEvent } from "../util/Observable.js";
 import { ObservableBase, observableProperty } from "../util/ObservableBase.js";
 import { Collection, CollectionChangeEvent, CollectionChangeType } from "../util/ObservableCollection.js";
+import { ObservableExpression } from "../util/ObservableExpression.js";
 import { PromiseSource } from "../util/PromiseSource.js";
+import { StringUtils } from "../util/StringUtils.js";
 import { UpdateCheckerClient, UpdateCheckerState } from "../util/UpdateCheckerClient.js";
 import { StdObservableCollectionChangeType } from "../util/collections/ReadOnlyStdObservableCollection.js";
 import { ActiveLoginViewModel } from "./ActiveLoginViewModel.js";
 import { ChannelViewModel } from "./ChannelViewModel.js";
 import { ChatChannelUserViewModel, ChatChannelViewModel } from "./ChatChannelViewModel.js";
 import { ColorThemeViewModel } from "./ColorThemeViewModel.js";
+import { DateFormatSpecifier, LocaleViewModel, TimeFormatSpecifier } from "./LocaleViewModel.js";
 import { PMConvoChannelViewModel } from "./PMConvoChannelViewModel.js";
 import { AboutViewModel } from "./dialogs/AboutViewModel.js";
 import { AlertOptions, AlertViewModel } from "./dialogs/AlertViewModel.js";
@@ -102,6 +106,8 @@ export class AppViewModel extends ObservableBase {
                 this.updateCheckerState = state;
             });
         })();
+
+        this.setupLocaleMonitoring();
     }
 
     isInStartup: boolean = true;
@@ -151,6 +157,101 @@ export class AppViewModel extends ObservableBase {
 
     @observableProperty
     appWindowState: HostWindowState;
+
+    @observableProperty
+    locale: LocaleViewModel = LocaleViewModel.default;
+
+    setupLocaleMonitoring(): IDisposable {
+        const setDefaultLocale = () => {
+            this.locale = LocaleViewModel.default;
+        };
+
+        const oe = new ObservableExpression(
+            () => [ this.configBlock.get("global.locale.dateFormat"), this.configBlock.get("global.locale.timeFormat") ],
+            (v) => {
+                if (v) {
+                    const dateFormat = v[0];
+                    const timeFormat = v[1];
+
+                    let dateFormatFunc: (d: Date, format: DateFormatSpecifier) => string;
+                    let timeFormatFunc: (d: Date, format: TimeFormatSpecifier) => string;
+
+                    switch (dateFormat) {
+                        case "mdyyyy":
+                            dateFormatFunc = (d: Date, format: DateFormatSpecifier) => {
+                                const mm = d.getMonth() + 1;
+                                const dd = d.getDate();
+                                const yy = d.getFullYear();
+                                return `${mm}/${dd}/${yy}`;
+                            };
+                            break;
+                        case "mmddyyyy":
+                            dateFormatFunc = (d: Date, format: DateFormatSpecifier) => {
+                                const mm = StringUtils.makeTwoDigitString(d.getMonth() + 1);
+                                const dd = StringUtils.makeTwoDigitString(d.getDate());
+                                const yy = d.getFullYear();
+                                return `${mm}/${dd}/${yy}`;
+                            };
+                            break;
+                        case "dmyyyy":
+                            dateFormatFunc = (d: Date, format: DateFormatSpecifier) => {
+                                const mm = d.getMonth() + 1;
+                                const dd = d.getDate();
+                                const yy = d.getFullYear();
+                                return `${dd}/${mm}/${yy}`;
+                            };
+                            break;
+                        case "ddmmyyyy":
+                            dateFormatFunc = (d: Date, format: DateFormatSpecifier) => {
+                                const mm = StringUtils.makeTwoDigitString(d.getMonth() + 1);
+                                const dd = StringUtils.makeTwoDigitString(d.getDate());
+                                const yy = d.getFullYear();
+                                return `${dd}/${mm}/${yy}`;
+                            };
+                            break;
+                        case "yyyymmdd":
+                            dateFormatFunc = (d: Date, format: DateFormatSpecifier) => {
+                                const mm = StringUtils.makeTwoDigitString(d.getMonth() + 1);
+                                const dd = StringUtils.makeTwoDigitString(d.getDate());
+                                const yy = d.getFullYear();
+                                return `${yy}/${mm}/${dd}`;
+                            };
+                            break;
+                        default:
+                        case "default":
+                            dateFormatFunc = LocaleViewModel.defaultConvertDate;
+                            break;
+                    }
+
+                    switch (timeFormat) {
+                        case "12h":
+                            timeFormatFunc = (d: Date, format: TimeFormatSpecifier) => {
+                                return new Intl.DateTimeFormat(undefined, { timeStyle: format, hourCycle: "h12" }).format(d);
+                            };
+                            break;
+                        case "24h":
+                            timeFormatFunc = (d: Date, format: TimeFormatSpecifier) => {
+                                return new Intl.DateTimeFormat(undefined, { timeStyle: format, hourCycle: "h23" }).format(d);
+                            };
+                            break;
+                        default:
+                        case "default":
+                            timeFormatFunc = LocaleViewModel.defaultConvertTime;
+                            break;
+                    }
+
+                    this.locale = new LocaleViewModel({ convertDate: dateFormatFunc, convertTime: timeFormatFunc });
+                }
+                else {
+                    setDefaultLocale();
+                }
+            },
+            (err) => {
+                setDefaultLocale();
+            }
+        );
+        return oe;
+    }
 
     @observableProperty
     get showTitlebar(): boolean {

--- a/browser/mainapp/src/viewmodel/LocaleViewModel.ts
+++ b/browser/mainapp/src/viewmodel/LocaleViewModel.ts
@@ -63,10 +63,8 @@ export class LocaleViewModel {
     private readonly _options: LocaleViewModelOptions;
 
     getTimeString(d: Date, format: TimeFormatSpecifier) {
-        console.log("getTimeString start", d);
         try {
             const result = this._options.convertTime(d, format);
-            console.log("time", d, result);
             return result;
         }
         catch (e) {
@@ -76,10 +74,8 @@ export class LocaleViewModel {
     }
 
     getDateString(d: Date, format: DateFormatSpecifier) {
-        console.log("getDateString start", d);
         try {
             const result = this._options.convertDate(d, format);
-            console.log("date", d, result);
             return result;
         }
         catch (e) {

--- a/browser/mainapp/src/viewmodel/LocaleViewModel.ts
+++ b/browser/mainapp/src/viewmodel/LocaleViewModel.ts
@@ -1,0 +1,102 @@
+
+const dtf = new Intl.DateTimeFormat(undefined, { timeStyle: "short" });
+const dtfDate = new Intl.DateTimeFormat(undefined, { day: 'numeric', month: 'numeric', year: 'numeric' });
+const dtfWithDate = new Intl.DateTimeFormat(undefined, { dateStyle: "short", timeStyle: "short" });
+const dtfLongWithLongDate = new Intl.DateTimeFormat(undefined, { dateStyle: "long", timeStyle: "long" });
+
+export interface LocaleViewModelOptions {
+    convertTime: (d: Date, format: TimeFormatSpecifier) => string;
+    convertDate: (d: Date, format: DateFormatSpecifier) => string;
+}
+
+// short = 5:52 PM
+// medium = 5:52:29 PM
+// long = 5:52:29 PM EDT
+// full = 5:52:29 PM Eastern Daylight Time
+export type TimeFormatSpecifier = "short" | "medium" | "long" | "full";
+
+// short = 8/4/25
+// nshort = 8/4/2025
+// medium = Aug 4, 2025
+// long = August 4, 2025
+// full = Monday, August 4, 2025
+export type DateFormatSpecifier = "short" | "nshort" | "medium" | "long" | "full";
+
+export class LocaleViewModel {
+    public static readonly defaultConvertTime = (d: Date, format: TimeFormatSpecifier) => {
+        return new Intl.DateTimeFormat(undefined, { timeStyle: format }).format(d);
+    };
+
+    public static readonly defaultConvertDate = (d: Date, format: DateFormatSpecifier) => {
+        switch (format) {
+            default:
+            case "nshort":
+                {
+                    const sb: string[] = [];
+                    for (let p of new Intl.DateTimeFormat(undefined, { day: "numeric", month: "numeric", year: "numeric" }).formatToParts(d)) {
+                        if (p.type == "year") {
+                            sb.push(d.getFullYear().toString());
+                        }
+                        else {
+                            sb.push(p.value);
+                        }
+                    }
+                    return sb.join("");
+                }
+            case "short":
+            case "medium":
+            case "long":
+            case "full":
+                return new Intl.DateTimeFormat(undefined, { timeStyle: format }).format(d);
+        }
+    };
+
+    static readonly default: LocaleViewModel = new LocaleViewModel();
+
+    constructor(options?: LocaleViewModelOptions) {
+        this._options = {
+            convertDate: options?.convertDate ?? LocaleViewModel.defaultConvertDate,
+            convertTime: options?.convertTime ?? LocaleViewModel.defaultConvertTime
+        };
+    }
+
+    private readonly _options: LocaleViewModelOptions;
+
+    getTimeString(d: Date, format: TimeFormatSpecifier) {
+        console.log("getTimeString start", d);
+        try {
+            const result = this._options.convertTime(d, format);
+            console.log("time", d, result);
+            return result;
+        }
+        catch (e) {
+            console.error(e);
+            throw e;
+        }
+    }
+
+    getDateString(d: Date, format: DateFormatSpecifier) {
+        console.log("getDateString start", d);
+        try {
+            const result = this._options.convertDate(d, format);
+            console.log("date", d, result);
+            return result;
+        }
+        catch (e) {
+            console.error(e);
+            throw e;
+        }
+    }
+
+    getShortTimeString(d: Date) {
+        return this.getTimeString(d, "short");
+    }
+
+    getNumericDateString(d: Date) {
+        return this.getDateString(d, "nshort");
+    }
+
+    getNumericDateWithShortTimeString(d: Date) {
+        return this.getNumericDateString(d) + " " + this.getShortTimeString(d);
+    }
+}

--- a/browser/mainapp/src/viewmodel/PMConvoChannelViewModel.ts
+++ b/browser/mainapp/src/viewmodel/PMConvoChannelViewModel.ts
@@ -339,13 +339,17 @@ export class PMConvoChannelViewModel extends ChannelViewModel {
                 message.type == ChannelMessageType.ROLL) {
 
                 this.hasPing = true;
-                this.activeLoginViewModel.appViewModel.soundNotification({ 
-                    eventType: AppNotifyEventType.PRIVATE_MESSAGE_RECEIVED,
-                    activeLoginViewModel: this.activeLoginViewModel,
-                    channel: this
-                });
+                this.playPingSound();
             }
         }
+    }
+
+    playPingSound() {
+        this.activeLoginViewModel.appViewModel.soundNotification({ 
+            eventType: AppNotifyEventType.PRIVATE_MESSAGE_RECEIVED,
+            activeLoginViewModel: this.activeLoginViewModel,
+            channel: this
+        });
     }
 
     protected increaseUnseenCountIfNecessary(): void {

--- a/browser/mainapp/src/viewmodel/dialogs/character-profile/CharacterProfileDetailSummaryInfoViewModel.ts
+++ b/browser/mainapp/src/viewmodel/dialogs/character-profile/CharacterProfileDetailSummaryInfoViewModel.ts
@@ -1,9 +1,11 @@
 import { ProfileInfo, ProfileFieldsInfoList, MappingList, ProfileFieldsSectionListItem } from "../../../fchat/api/FListApi";
 import { ObservableBase, observableProperty } from "../../../util/ObservableBase";
 import { StringUtils } from "../../../util/StringUtils";
+import { AppViewModel } from "../../AppViewModel";
 
 export class CharacterProfileDetailSummaryInfoViewModel extends ObservableBase {
     constructor(
+        appViewModel: AppViewModel,
         private readonly profileInfo: ProfileInfo,
         private readonly profileFieldsInfoList: ProfileFieldsInfoList,
         private readonly mappingList: MappingList
@@ -20,8 +22,8 @@ export class CharacterProfileDetailSummaryInfoViewModel extends ObservableBase {
 
         const createdAt = new Date(profileInfo.created_at * 1000);
         const updatedAt = new Date(profileInfo.updated_at * 1000);
-        this.created = StringUtils.dateToString(createdAt, { dateStyle: 'medium', timeStyle: 'short' });
-        this.lastUpdated = StringUtils.dateToString(updatedAt, { dateStyle: 'medium', timeStyle: 'short' });
+        this.created = StringUtils.dateToString(appViewModel.locale, createdAt, { dateStyle: 'medium', timeStyle: 'short' });
+        this.lastUpdated = StringUtils.dateToString(appViewModel.locale, updatedAt, { dateStyle: 'medium', timeStyle: 'short' });
         this.views = StringUtils.numberToString(profileInfo.views, {});
         this.timezone = profileInfo.timezone ?
             (profileInfo.timezone == 0 ? "GMT"

--- a/browser/mainapp/src/viewmodel/dialogs/character-profile/CharacterProfileDetailViewModel.ts
+++ b/browser/mainapp/src/viewmodel/dialogs/character-profile/CharacterProfileDetailViewModel.ts
@@ -67,7 +67,7 @@ export class CharacterProfileDetailViewModel extends ObservableBase {
 
         super();
 
-        this.summaryInfo = new CharacterProfileDetailSummaryInfoViewModel(profileInfo, profileFieldsInfo, mappingList);
+        this.summaryInfo = new CharacterProfileDetailSummaryInfoViewModel(activeLoginViewModel.appViewModel, profileInfo, profileFieldsInfo, mappingList);
         this.description = profileInfo.description;
 
         // Grab correctly-cased character name from profile data

--- a/browser/mainapp/styles/bbcode.css
+++ b/browser/mainapp/styles/bbcode.css
@@ -40,6 +40,8 @@
     height: var(--eicon-size);
     max-width: var(--eicon-size);
     max-height: var(--eicon-size);
+    --eicon-width: var(--eicon-size);
+    --eicon-height: var(--eicon-size);
     vertical-align: top;
     /* background: inherit; */
     /* will-change: transform; */

--- a/browser/mainapp/styles/common.css
+++ b/browser/mainapp/styles/common.css
@@ -261,3 +261,6 @@ select.themed.invalid-value {
 .hidden { display: none !important; }
 
 
+x-eicondisplay { display: inline-block; user-select: all;; line-height: 0px; font-size: 0px; }
+x-eicondisplay img { width: inherit; height: inherit; }
+x-eicondisplay img.blocked { filter: blur(10px); }

--- a/browser/mainapp/styles/components/EIconDisplay.css
+++ b/browser/mainapp/styles/components/EIconDisplay.css
@@ -1,0 +1,21 @@
+:host {
+    display: inline-block;
+    user-select: all;
+}
+
+:root {
+    line-height: 0px;
+    user-select: none;
+}
+
+#elMain {
+    display: contents;
+}
+
+#elMain img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: var(--eicon-width);
+    height: var(--eicon-height);
+}

--- a/browser/mainapp/styles/components/MainInterface.css
+++ b/browser/mainapp/styles/components/MainInterface.css
@@ -62,6 +62,7 @@
         "leftbar splitterhandle stage";
 
     contain: strict;
+    /* will-change: transform; */
 }
 .chatui.not-loaded { display: none; }
 .dialogstack {
@@ -72,6 +73,7 @@
     left: 0;
     width: 100%;
     height: 100%;
+    contain: strict;
 }
 
 #elMain.has-unclosed-dialogs .chatui {
@@ -126,6 +128,8 @@
     transform: scale(1);
     opacity: 1;
     transition: transform 0.2s, opacity 0.2s;
+
+    contain: strict;
 }
 
 .dialogstack > .inactive {

--- a/browser/mainapp/styles/components/dialogs/SettingsDialog.css
+++ b/browser/mainapp/styles/components/dialogs/SettingsDialog.css
@@ -168,7 +168,7 @@
     margin-left: 10px;
 }
 
-.setting-using-inherited { opacity: 0.7;}
+.setting-using-inherited { color: rgba(255, 255, 255, 0.5); }
 .setting-revert-to-inherited { color: yellow; }
 .revert-link {
     cursor: pointer;

--- a/host/shared/XarChat.Backend/Features/AppConfiguration/IAppConfiguration.cs
+++ b/host/shared/XarChat.Backend/Features/AppConfiguration/IAppConfiguration.cs
@@ -23,6 +23,8 @@ namespace XarChat.Backend.Features.AppConfiguration
 
         bool DisableGpuAcceleration { get; }
 
+        string? BrowserLanguage { get; }
+
 
         IEnumerable<KeyValuePair<string, JsonNode>> GetAllArbitraryValues();
 

--- a/host/shared/XarChat.Backend/Features/AppConfiguration/Impl/AppConfigurationImpl.cs
+++ b/host/shared/XarChat.Backend/Features/AppConfiguration/Impl/AppConfigurationImpl.cs
@@ -324,6 +324,11 @@ namespace XarChat.Backend.Features.AppConfiguration.Impl
             (_commandLineOptions.DisableGpuAcceleration == true) ? true :
             !(Convert.ToBoolean(GetArbitraryValueString("global.useGpuAcceleration") ?? "true"));
 
+        public string? BrowserLanguage =>
+            _commandLineOptions.BrowserLanguage ??
+            GetArbitraryValueString("global.spellCheckLanguage") ??
+            null;
+
         public IEnumerable<KeyValuePair<string, JsonNode>> GetAllArbitraryValues()
         {
             var acd = _appConfigData;

--- a/host/shared/XarChat.Backend/Features/CommandLine/ICommandLineOptions.cs
+++ b/host/shared/XarChat.Backend/Features/CommandLine/ICommandLineOptions.cs
@@ -23,5 +23,7 @@ namespace XarChat.Backend.Features.CommandLine
         string? ProfilePath { get; }
 
         bool DisableGpuAcceleration { get; }
+
+        string? BrowserLanguage { get; }
     }
 }

--- a/host/shared/XarChat.Backend/Features/CommandLine/Impl/ArrayCommandLineOptions.cs
+++ b/host/shared/XarChat.Backend/Features/CommandLine/Impl/ArrayCommandLineOptions.cs
@@ -88,6 +88,15 @@ namespace XarChat.Backend.Features.CommandLine.Impl
                     case "--disable-gpu":
                         this.DisableGpuAcceleration = true;
                         break;
+                    case "--lang":
+                        {
+                            var lang = GetNextOrNull();
+                            if (!String.IsNullOrWhiteSpace(lang))
+                            {
+                                this.BrowserLanguage = lang;
+                            }
+                        }
+                        break;
                 }
             }
         }
@@ -107,5 +116,7 @@ namespace XarChat.Backend.Features.CommandLine.Impl
         public string? ProfilePath { get; private set; } = null;
 
         public bool DisableGpuAcceleration { get; private set; } = false;
+
+        public string? BrowserLanguage { get; private set; } = null;
     }
 }

--- a/host/shared/XarChat.Backend/Features/LocaleList/ILocaleList.cs
+++ b/host/shared/XarChat.Backend/Features/LocaleList/ILocaleList.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XarChat.Backend.Features.LocaleList
+{
+    public interface ILocaleList
+    {
+        Task<List<LocaleInfo>> EnumerateAvailableLocalesAsync(CancellationToken cancellationToken);
+    }
+
+    public class LocaleInfo
+    {
+        public required string Code { get; set; }
+
+        public required string NativeName { get; set; }
+    }
+}

--- a/host/shared/XarChat.Backend/UrlHandlers/XCHostFunctions/CommandHandlers/GetLocaleList/GetLocaleListCommandHandler.cs
+++ b/host/shared/XarChat.Backend/UrlHandlers/XCHostFunctions/CommandHandlers/GetLocaleList/GetLocaleListCommandHandler.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using XarChat.Backend.Common;
+using XarChat.Backend.Features.LocaleList;
+
+namespace XarChat.Backend.UrlHandlers.XCHostFunctions.CommandHandlers.GetLocaleList
+{
+    internal class GetLocaleListCommandHandler : XCHostCommandHandlerBase
+    {
+        private readonly ILocaleList _localeList;
+
+        public GetLocaleListCommandHandler(ILocaleList localeList)
+        {
+            _localeList = localeList;
+        }
+
+        protected override async Task HandleCommandAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _localeList.EnumerateAvailableLocalesAsync(cancellationToken);
+
+                var respObj = new JsonObject();
+                respObj.Add("locales", new JsonArray(
+                    result.Select(x =>
+                    {
+                        var node = new JsonObject();
+                        node.Add("code", x.Code);
+                        node.Add("name", x.NativeName);
+                        return node;
+                    })
+                    .ToArray()
+                ));
+                await CommandContext.WriteMessage($"gotLocales " +
+                    JsonSerializer.Serialize(respObj, SourceGenerationContext.Default.JsonObject));
+            }
+            catch (Exception ex)
+            {
+                var respObj = new JsonObject();
+                respObj.Add("error", ex.Message);
+                await CommandContext.WriteMessage($"gotLocalesError " +
+                    JsonSerializer.Serialize(respObj, SourceGenerationContext.Default.JsonObject));
+            }
+        }
+    }
+}

--- a/host/shared/XarChat.Backend/XarChatBackend.cs
+++ b/host/shared/XarChat.Backend/XarChatBackend.cs
@@ -73,6 +73,7 @@ using XarChat.Backend.UrlHandlers.XCHostFunctions.CommandHandlers.ZoomLevel;
 using XarChat.Backend.UrlHandlers.XCHostFunctions.CommandHandlers.GetMemo;
 using XarChat.Backend.Features.StyleUpdateWatcher;
 using XarChat.Backend.Features.EIconFavoriteManager;
+using XarChat.Backend.UrlHandlers.XCHostFunctions.CommandHandlers.GetLocaleList;
 
 namespace XarChat.Backend
 {
@@ -353,6 +354,7 @@ namespace XarChat.Backend
             services.AddXCHostCommandHandler<SubmitEIconMetadataCommandHandler>("submiteiconmetadata");
             services.AddXCHostCommandHandler<SetZoomLevelCommandHandler>("setZoomLevel");
             services.AddXCHostCommandHandler<GetMemoCommandHandler>("getMemo");
+            services.AddXCHostCommandHandler<GetLocaleListCommandHandler>("getLocales");
         }
 
         private object _concurrentCountLock = new object();

--- a/host/win32-webview2/XarChatWin32WebView2/Properties/launchSettings.json
+++ b/host/win32-webview2/XarChatWin32WebView2/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "MinimalWin32Test": {
       "commandName": "Project",
-      "commandLineArgs": "-d -p C:\\Users\\drysa\\AppData\\Local\\XarChatz-debug -zzc E:\\src-XarChat\\browser\\mainapp --zzautoupdate:url=https://localhost:44314/xarchat/api/AutoUpdate/GetUpdateInfo --devtoolsonlaunch --zzshowinitwindow -zzw wss://flprox.evercrest.com/connect"
+      "commandLineArgs": "-d -p C:\\Users\\drysa\\AppData\\Local\\XarChatz-debug -zzc E:\\src-XarChat\\browser\\mainapp --zzautoupdate:url=https://localhost:44314/xarchat/api/AutoUpdate/GetUpdateInfo --devtoolsonlaunch --zzshowinitwindow -zzw wss://flprox.evercrest.com/connect --lang en-GB"
     }
   }
 }

--- a/host/win32-webview2/XarChatWin32WebView2/UI/BrowserWindow.cs
+++ b/host/win32-webview2/XarChatWin32WebView2/UI/BrowserWindow.cs
@@ -506,13 +506,19 @@ namespace MinimalWin32Test.UI
                     browserArguments.Add("--disable-software-rasterizer");
                 }
 
+                string? browserLanguage = null;
+                if (!String.IsNullOrWhiteSpace(appCfg.BrowserLanguage) && appCfg.BrowserLanguage != "default")
+                {
+                    browserLanguage = appCfg.BrowserLanguage;
+                }
+
                 WriteToStartupLog("BrowserWindow.OnHandleCreated - Creating CoreWebView2Environment");
                 var cenv = await Microsoft.Web.WebView2.Core.CoreWebView2Environment.CreateAsync(
                     browserExecutableFolder: null,
                     userDataFolder: Path.Combine(appDataFolder, "WebView2Data"),
                     new Microsoft.Web.WebView2.Core.CoreWebView2EnvironmentOptions(
                         additionalBrowserArguments: String.Join(" ", browserArguments),
-                        language: null,
+                        language: browserLanguage,
                         targetCompatibleBrowserVersion: null,
                         allowSingleSignOnUsingOSPrimaryAccount: false
                     ));
@@ -732,8 +738,8 @@ namespace MinimalWin32Test.UI
 
                 if (shouldRemove)
                 {
-                    e.MenuItems.RemoveAt(i);
-                    i--;
+                    //e.MenuItems.RemoveAt(i);
+                    //i--;
                 }
                 else
                 {

--- a/host/win32/XarChat.Backend.Win32/LocaleList/Win32LocaleList.cs
+++ b/host/win32/XarChat.Backend.Win32/LocaleList/Win32LocaleList.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XarChat.Backend.Features.LocaleList;
+using XarChat.Native.Win32;
+
+namespace XarChat.Backend.Win32.LocaleList
+{
+    internal class Win32LocaleList : ILocaleList
+    {
+        public Task<List<LocaleInfo>> EnumerateAvailableLocalesAsync(CancellationToken cancellationToken)
+        {
+            var result = new List<LocaleInfo>();
+            foreach (var locale in WinNLS.EnumSystemLocalesEx())
+            {
+                var ci = new CultureInfo(locale);
+
+                result.Add(new LocaleInfo() { Code = locale, NativeName = ci.NativeName });
+            }
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/host/win32/XarChat.Backend.Win32/Win32BackendServiceSetup.cs
+++ b/host/win32/XarChat.Backend.Win32/Win32BackendServiceSetup.cs
@@ -9,6 +9,7 @@ using XarChat.Backend.Features.AppSettings;
 using XarChat.Backend.Features.CrashLogWriter;
 using XarChat.Backend.Features.FileChooser;
 using XarChat.Backend.Features.IdleDetection;
+using XarChat.Backend.Features.LocaleList;
 using XarChat.Backend.Features.MemoryHinter;
 using XarChat.Backend.Features.NotificationBadge;
 using XarChat.Backend.Features.UpdateChecker;
@@ -18,6 +19,7 @@ using XarChat.Backend.Win32.CrashLogWriterCallback;
 using XarChat.Backend.Win32.DataProtection;
 using XarChat.Backend.Win32.FileChooser;
 using XarChat.Backend.Win32.IdleDetection;
+using XarChat.Backend.Win32.LocaleList;
 using XarChat.Backend.Win32.MemoryHinter;
 using XarChat.Backend.Win32.NotificationBadge;
 
@@ -45,6 +47,7 @@ namespace XarChat.Backend.Win32
             services.AddSingleton<IMemoryHinter, Win32MemoryHinter>();
             services.AddSingleton<IFileChooser, Win32FileChooser>();
             services.AddSingleton<ICrashLogWriterCallback, Win32CrashLogWriterCallback>();
+            services.AddSingleton<ILocaleList, Win32LocaleList>();
         }
     }
 }

--- a/host/win32/XarChat.Native.Win32/NativeMethods.txt
+++ b/host/win32/XarChat.Native.Win32/NativeMethods.txt
@@ -44,3 +44,6 @@ EmptyWorkingSet
 NtQueryInformationProcess
 OpenProcess
 CloseHandle
+// WinNLS
+//EnumSystemLocalesEx
+EnumUILanguages

--- a/host/win32/XarChat.Native.Win32/WinNLS.cs
+++ b/host/win32/XarChat.Native.Win32/WinNLS.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Wdk;
+using Windows.Win32.Globalization;
+
+namespace XarChat.Native.Win32
+{
+    public static class WinNLS
+    {
+        public static List<string> EnumSystemLocalesEx()
+        {
+            var result = new List<string>();
+
+            Windows.Win32.PInvoke.EnumUILanguages(
+                lpUILanguageEnumProc: (param0, param1) =>
+                {
+                    var languageName = param0.ToString();
+                    result.Add(languageName);
+                    return true;
+                },
+                dwFlags: MUI_LANGUAGE_KIND.MUI_LANGUAGE_NAME,
+                lParam: 0);
+
+            //Windows.Win32.PInvoke.EnumSystemLocalesEx(
+            //    lpLocaleEnumProcEx: (dwLocaleName, flags, param) => 
+            //    {
+            //        result.Add(dwLocaleName.ToString());
+            //        return true;
+            //    }, 
+            //    dwFlags: LOCALETYPE.LOCALE_ALL, 
+            //    lParam: 0);
+
+            return result;
+        }
+
+        public static class MUI_LANGUAGE_KIND
+        {
+            public const uint MUI_LANGUAGE_ID = 0x4; // enumerate all named based locales
+            public const uint MUI_LANGUAGE_NAME = 0x8; // enumerate all named based locales
+
+        }
+        //public static class LOCALETYPE
+        //{
+        //    public const uint LOCALE_ALL = 0x00000000; // enumerate all named based locales
+        //    public const uint LOCALE_WINDOWS = 0x00000001; // shipped locales and/or replacements for them
+        //    public const uint LOCALE_SUPPLEMENTAL = 0x00000002; // supplemental locales only
+        //    public const uint LOCALE_ALTERNATE_SORTS = 0x00000004; // alternate sort locales
+        //    public const uint LOCALE_NEUTRALDATA = 0x00000010; // Locales that are "neutral" (language only, region data is default)
+        //    public const uint LOCALE_SPECIFICDATA = 0x00000020; // Locales that contain language and region data
+        //}
+    }
+}


### PR DESCRIPTION
* Updated locale handling
  - You can now select which language the XarChat UI uses.  This impacts date/time formatting and spellcheck.
  - There is a new setting under Global to choose
  - It can also be specified using the command line (e.g. `XarChat.exe --lang en-US`)
* XarChat releases are now signed executables
* Fixed EIcon blocking (right-click an eicon to block/unblock it)
* Added an setting to open a PM tab when a user starts typing at you (instead of the default behavior of waiting until they've actually sent you a message)